### PR TITLE
added endpoint to wipe a users data

### DIFF
--- a/queries/userQueries.js
+++ b/queries/userQueries.js
@@ -111,6 +111,35 @@ function removeUser(req, res, callback) {
   }
 }
 
+// Replaces all user information with anonymous dummy data.
+function wipeUser(req, res, callback) {
+  if (req.body.email === undefined) {
+    callback(cbs.cbMsg(true, { error: 'Email not provided!' }));
+  } else if (req.body.email === '') {
+    callback(cbs.cbMsg(true, { error: 'Empty email provided!' }));
+  } else {
+    const update = {
+      username: 'deleted user',
+      email: '0@0',
+      phone_number: '0',
+      location: 'deleted location',
+      avatar_url: 'deleted avatar',
+    };
+    userModel.User.findOneAndUpdate(
+      { email: req.body.email },
+      update,
+      { new: true },
+      (err, result) => {
+        console.log(err);
+        console.log(result);
+        if (err) callback(cbs.cbMsg(true, { error: err }));
+        else if (!result) callback(cbs.cbMsg(true, { error: `No user with email ${req.body.email} found!` }));
+        else callback(cbs.cbMsg(false, result));
+      },
+    );
+  }
+}
+
 // General function for updating a user document with the provided paramters.
 function updateUser(req, res, callback) {
   const conditions = {
@@ -322,6 +351,7 @@ module.exports = {
   getHighscore,
   updateHighscore,
   removeUser,
+  wipeUser,
   updateUser,
   getUser,
   getAllUsers,

--- a/routes/users.js
+++ b/routes/users.js
@@ -27,6 +27,10 @@ router.post('/removeuser/', (req, res) => {
   queries.removeUser(req, res, (result) => { res.send(result.message); });
 });
 
+router.post('/wipeuser/', (req, res) => {
+  queries.wipeUser(req, res, (result) => { res.send(result.message); });
+});
+
 router.post('/updateuser/', (req, res) => {
   queries.updateUser(req, res, (result) => { res.send(result.message); });
 });


### PR DESCRIPTION
#### What does this PR do?

Adds endpoint to wipe user data (replace it with dummy data instead of removing the entire user) as requested by Adrian.

##### Why are we doing this? Any context or related work?
To effectively remove a user without removing the actual user record in the database.

#### Where should a reviewer start?
n/a